### PR TITLE
Support multiple titleDetails

### DIFF
--- a/src/entities/DescriptiveDetail.ts
+++ b/src/entities/DescriptiveDetail.ts
@@ -49,7 +49,8 @@ export class DescriptiveDetail {
       EPublicationTechnicalProtection
     );
 
-    this.titleDetail = new TitleDetail(json.TitleDetail[0]);
+    this.titleDetails =
+        (json.TitleDetail || []).map((t) => new TitleDetail(t)) || [];
     this.collections =
       (json.Collection || []).map((c) => new Collection(c)) || [];
     this.contributors =
@@ -64,7 +65,7 @@ export class DescriptiveDetail {
   productFormDetail: ProductFormDetailEnum;
   primaryContentType: ProductContentTypeEnum;
   epubTechnicalProtection: EPublicationTechnicalProtectionEnum;
-  titleDetail: TitleDetail;
+  titleDetails: TitleDetail[];
   collections: Collection[];
   contributors: Contributor[];
   languages: Language[];

--- a/test/bokbasen.test.ts
+++ b/test/bokbasen.test.ts
@@ -40,17 +40,33 @@ describe("Feeds", () => {
             primaryContentType: null,
             epubTechnicalProtection: "DigitalWatermarking",
             collections: [ ],
-            titleDetail: {
+            titleDetails: [{
               titleType:
                 "DistinctiveTitleBookCoverTitleSerialTitleOnItemSerialContentItemOrReviewedResource",
               titleElements: [
                 {
                   partNumber: null,
                   titleElementLevel: "Product",
+                  titlePrefix: null,
                   titleText: "Den 5. bølgen",
+                  titleWithoutPrefix: null,
                 },
               ],
             },
+            {
+              titleType:
+                  "TitleInOriginalLanguage",
+              titleElements: [
+                {
+                  partNumber: null,
+                  titleElementLevel: "Product",
+                  titlePrefix: null,
+                  titleText: "The 5th wave",
+                  titleWithoutPrefix: null,
+                },
+              ],
+            }
+            ],
             contributors: [
               {
                 contributorRole: "ByAuthor",

--- a/test/feed.tests.ts
+++ b/test/feed.tests.ts
@@ -43,12 +43,16 @@ describe("Feeds", () => {
                     {
                       partNumber: null,
                       titleElementLevel: "CollectionLevel",
+                      titlePrefix: null,
                       titleText: "Kampen om Tusenvärld",
+                      titleWithoutPrefix: null,
                     },
                     {
                       partNumber: null,
                       titleElementLevel: "Product",
+                      titlePrefix: null,
                       titleText: "2",
+                      titleWithoutPrefix: null,
                     },
                   ],
                   titleType:
@@ -56,22 +60,26 @@ describe("Feeds", () => {
                 },
               },
             ],
-            titleDetail: {
+            titleDetails: [{
               titleType:
                 "DistinctiveTitleBookCoverTitleSerialTitleOnItemSerialContentItemOrReviewedResource",
               titleElements: [
                 {
                   partNumber: null,
                   titleElementLevel: "Product",
+                  titlePrefix: null,
                   titleText: "Moby Dick – Valen",
+                  titleWithoutPrefix: null,
                 },
                 {
                   partNumber: null,
                   titleElementLevel: "CollectionLevel",
+                  titlePrefix: null,
                   titleText: "Series",
+                  titleWithoutPrefix: null,
                 },
               ],
-            },
+            }],
             contributors: [
               {
                 contributorRole: "ByAuthor",
@@ -223,17 +231,19 @@ describe("Feeds", () => {
             primaryContentType: "TextEyeReadable",
             epubTechnicalProtection: "DigitalWatermarking",
             collections: [],
-            titleDetail: {
+            titleDetails: [{
               titleType:
                 "DistinctiveTitleBookCoverTitleSerialTitleOnItemSerialContentItemOrReviewedResource",
               titleElements: [
                 {
                   partNumber: null,
                   titleElementLevel: "Product",
+                  titlePrefix: null,
                   titleText: "Gemmesteder",
+                  titleWithoutPrefix: null,
                 },
               ],
-            },
+            }],
             contributors: [
               {
                 contributorRole: "ByAuthor",


### PR DESCRIPTION
Some Onix objects have several titleDetails, this fix changes ```titleDetail: TitleDetail -> titleDetails: TitleDetails[]``` in the DescriptiveDetail to handle all instances of titleDetail.